### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![BCColor](https://github.com/boycechang/BCColor/blob/master/icon.png)
 
-#BCColor
+# BCColor
 **A lightweight but powerful color kit (Swift)**
 
 
@@ -77,7 +77,7 @@ UIColor.radialGradientColor(frame, colors: [UIColor.blueColor(), UIColor.greenCo
 
 
 
-##Misc
+## Misc
 
 Author: [Boyce Chang](http://www.boycechang.com)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
